### PR TITLE
Add E5E and docs to trigger from library repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,75 @@
 
 This repository holds the templates and configuration for our go vanity URL website at go.anx.io.
 
-### Contributing
+
+## Usage
+
+* add your package to `packages.yaml`, optionally overriding `targetName` and `summary`
+* add a GitHub actions workflow to trigger updates when code is pushed to your repository
+* be sure your `go.mod` uses the correct import path `go.anx.io/$targetName`
+* profit :)
+
+You can look at [anexia-it/go-anxcloud#96](https://github.com/anexia-it/go-anxcloud/pull/96) for an example
+what to do, there is also a handy `sed` in the comments to change import paths over the whole repository.
+
+```yaml
+# anexia-it/go.anx.io/packages.yaml
+
+# This package can be imported as go.anx.io/awesomeLibrary
+- source:     https://github.com/anexia-it/go-awesome-library.git
+  targetName: awesomeLibrary
+  summary:    This library does some really awesome things
+
+# This package can be imported as go.anx.io/go-boring-library
+- source:     https://github.com/anexia-it/go-boring-library.git
+```
+
+`targetName` defaults to the last part of the URL without the `.git`, `summary` to the first top-level
+header in `README.md` on the default branch.
+
+
+Add this as a new workflow or add the job `trigger` to one of your existing workflows. You can also modify it
+to run after your tests went through.
+
+```yaml
+# anexia-it/go-awesome-library/.github/workflows/push.yaml
+
+name: Trigger go.anx.io update
+on:
+  push:
+    branches:
+    - "**"
+
+jobs:
+  trigger:
+    name:    Trigger go.anx.io update
+    runs-on: ubuntu-latest
+    steps:
+    - uses: anexia-it/go.anx.io@main
+      env:
+        GOANXIO_E5E_TOKEN: "${{ secrets.GOANXIO_E5E_TOKEN }}"
+```
+
+
+## The update trigger
+
+Triggering workflows in a repository from another repositories workflow needs a personal access token (PATs) to
+create a `repository_dispatch` event, which workflows can be triggered on. Since those PATs are powerful and we
+want as less config as possible in each library (so not adding this token to every libraries settings), we use
+an E5E function to do the actual GitHub API call. This way we have that token securely in our own infrastructure
+in a piece of code that can only trigger this specific API.
+
+The E5E function is "System Engineering / github-dispatch / Trigger go.anx.io rebuild" and called via Frontier
+"System Engineering / github-dispatch / trigger go.anx.io rebuild".
+
+
+## Contributing
 
 Contributions are welcome! Read the [Contributing Guide](CONTRIBUTING.md) for more information.
 
-### Licensing
+Only packages by Anexia will be published on go.anx.io, though.
+
+
+## Licensing
 
 See [LICENSE](LICENSE) for more information.

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,11 @@
+name:        Update go.anx.io
+description: Triggers the build workflow for go.anx.io
+runs:
+  using: composite
+  steps:
+  - name: Trigger rebuild of go.anx.io
+    shell: sh
+    run: >
+      curl -X POST -sSf
+      --oauth2-bearer "$GOANXIO_E5E_TOKEN"
+      https://frontier.anexia-it.com/2d5a3a0959104b9fb1f57e3687a0fe07/gh-dispatch-2022011301/github-dispatch/go.anx.io/rebuild

--- a/e5e/trigger.py
+++ b/e5e/trigger.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import os
+import base64
+import json
+import urllib.request
+
+def trigger(event, context):
+    if not _check_auth(event):
+        return {
+            "status": 401,
+            "data":  "Authentication required",
+            "type":  "text",
+        }
+
+    _trigger_goanxio_workflow()
+
+    return {
+        "status": 200,
+        "data":  "OK",
+        "type":  "text",
+    }
+
+def _check_auth(event):
+    cfg_token = os.getenv("GOANXIO_E5E_TOKEN")
+
+    if    not event                      \
+       or not 'request_headers' in event \
+       or not 'authorization'   in event['request_headers']:
+        return False
+
+    auth       = event['request_headers']['authorization']
+    auth_parts = auth.split(" ", 2)
+
+    return len(auth_parts) == 2             \
+           and auth_parts[0] == "Bearer"    \
+           and auth_parts[1] == cfg_token
+
+def _trigger_goanxio_workflow():
+    cfg_gh_token_user = "anx-release"
+    cfg_gh_token      = os.getenv("GOANXIO_TOKEN")
+
+    # using HTTPBasicAuthHandler does not seem to work with github, probably due to
+    # no X-WWW-Authenticate header being sent by it.
+    auth         = ('%s:%s' % (cfg_gh_token_user, cfg_gh_token))
+    encoded_auth = base64.b64encode(auth.encode('ascii')).decode('ascii')
+
+    url = 'https://api.github.com/repos/anexia-it/go.anx.io/dispatches'
+
+    request = urllib.request.Request(
+        url,
+        headers={
+            'Content-Type': 'application/json; charset=utf-8',
+            'Authorization': 'Basic ' + encoded_auth,
+        },
+        data=json.dumps({
+            "event_type": "rebuild_pages",
+        }).encode('utf-8'),
+    )
+
+    response = urllib.request.urlopen(request)


### PR DESCRIPTION
This adds the E5E code to trigger a rebuild of go.anx.io from another repository, keeping the token for triggering this in our infrastructure (and giving me an excuse to learn how E5E can be used).

It also adds the docs how to use it for packages.