### PR TITLE
Set target name for go-e5e

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -1,4 +1,5 @@
 - source: https://github.com/anexia-it/go-anxcloud.git
 - source: https://github.com/anexia-it/go-cloudlog.git
 - source: https://github.com/anexia/go-e5e.git
+  targetName: e5e
   summary: Support library to help Go developers build Anexia e5e functions


### PR DESCRIPTION
*Changes:*
* Set the target name for `go-e5e` to remove the duplication of `go`