### PR TITLE
style: outdated major version notice fix

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -72,6 +72,7 @@ body > header {
 
   min-height: calc(2em + 45px);
   box-sizing: border-box;
+  padding-bottom: 2.5em;
 }
 
 body > header h1 {
@@ -91,7 +92,15 @@ body > header > nav {
   line-height: 1em;
   padding-left: 0;
   padding-right: 0;
-  margin-bottom: 2.5em;
+}
+
+.outdatedVersionNotice {
+  display: inline-block;
+  margin-top: 1em;
+}
+
+.outdatedVersionNotice:before {
+  content: '🛈';
 }
 
 body > header nav label {
@@ -231,16 +240,6 @@ div.dropdown {
 .dropdown menu li.majorVersion {
   font-weight: bold;
   padding-left: 0.5em;
-}
-
-.outdatedVersionNotice {
-  display: inline-block;
-  margin: 1em;
-  margin-top: 0;
-}
-
-.outdatedVersionNotice:before {
-  content: '🛈';
 }
 
 body > main {


### PR DESCRIPTION
just an old branch that was lying around, pushed already even

changes the "old major version" notice layout a bit:

### Before

![image](https://github.com/anexia-it/go.anx.io/assets/2444973/6b9207a8-5103-4a83-9585-85839b457b6c)

### After

![image](https://github.com/anexia-it/go.anx.io/assets/2444973/973d8be9-0db2-4890-9d48-be369ed75b97)
