### PR TITLE
SYSENG-1828: Add external-dns-webhook

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -3,3 +3,5 @@
 - source: https://github.com/anexia/go-e5e.git
   targetName: e5e
   summary: Support library to help Go developers build Anexia e5e functions
+- source: https://github.com/anexia/k8s-external-dns-webhook.git
+  targetName: external-dns-webhook


### PR DESCRIPTION
Although it's not a library and likely not going to be imported, I add it here for consistency with other project.